### PR TITLE
Hotfix - Adding provider blocks

### DIFF
--- a/TFC/providers.tf
+++ b/TFC/providers.tf
@@ -22,18 +22,10 @@ terraform {
   }
 }
 
-provider "tfe" {
-  # Configuration options
-}
+provider "tfe" {}
 
-provider "http" {
-  # Configuration options
-}
+provider "http" {}
 
-provider "null" {
-  # Configuration options
-}
+provider "null" {}
 
-provider "local" {
-  # Configuration options
-}
+provider "local" {}


### PR DESCRIPTION
When testing the tool locally, I had to specifically add the provider blocks in the providers.tf file as it was raising "Invalid Provider Configuration". 

Adding this PR just in case someone else gets an error.