### PR TITLE
Fix: using `" "` as placeholder for secrets causes deployment logs unreadable

### DIFF
--- a/TFC/parse_workspaces.tf
+++ b/TFC/parse_workspaces.tf
@@ -8,7 +8,7 @@ locals {
           hcl       = env_var.hcl
           name      = env_var.name
           sensitive = env_var.sensitive
-          value     = env_var.sensitive ? " " : env_var.value
+          value     = env_var.sensitive ? "secret_value_from_terraform_cloud" : env_var.value
           type      = env_var.category == "terraform" ? "terraform" : "environment"
         }
       ]


### PR DESCRIPTION
Currently, the placeholder for secret values is `" "`.
env0 replaces secret values with an asterix string, i.e. `"*************"`, and that causes the logs to become unreadable

solution:
use a non-empty placeholder for secrets