### PR TITLE
Properly handle newline characters in variable values

### DIFF
--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -23,7 +23,7 @@ resource "env0_environment" "${workspace.name}" {
 
     configuration {
         name = "${env_var.name}"
-        value = "${replace(replace(env_var.value, "\"", "\\\""), "\n", "\\n")}"
+        value = "${format("%q", env_var.value)}"
         is_sensitive = ${env_var.sensitive}
         %{ if env_var.hcl ~}
         schema_format = "HCL"

--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -23,7 +23,7 @@ resource "env0_environment" "${workspace.name}" {
 
     configuration {
         name = "${env_var.name}"
-        value = "${format("%q", env_var.value)}"
+        value = ${format("%q", env_var.value)}
         is_sensitive = ${env_var.sensitive}
         %{ if env_var.hcl ~}
         schema_format = "HCL"

--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -23,7 +23,7 @@ resource "env0_environment" "${workspace.name}" {
 
     configuration {
         name = "${env_var.name}"
-        value = "${replace(env_var.value, "\"", "\\\"")}"
+        value = "${replace(replace(env_var.value, "\"", "\\\""), "\n", "\\n")}"
         is_sensitive = ${env_var.sensitive}
         %{ if env_var.hcl ~}
         schema_format = "HCL"


### PR DESCRIPTION
This can happen when a variable contains a public key.