### PR TITLE
FEAT: support modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ terraform.rc
 
 # "out" directories
 **/out/*
+
+# lock files
+**/.terraform.lock.hcl

--- a/TFC/README.md
+++ b/TFC/README.md
@@ -1,4 +1,4 @@
-# Migrate from TFC 
+# Migrate from TFC
 
 ## Usage
 
@@ -8,7 +8,9 @@
 tfc_token = "your-tfc-token"
 tfc_organization = "your-tfc-organization"
 ```
+
 you may also specify the following optional variables:
+
 ```hcl
 tfc_workspace_names = ["array of workspace names to export", "wildcards supported"]
 tfc_workspace_include_tags = ["array of tags to include", "wildcards are not supported"]
@@ -18,17 +20,19 @@ tfc_workspace_exclude_tags = ["array of tags to exclude", "wildcards are not sup
 Note: names and tags are applied together, "with AND operator". exclude tags take precedence over include tags and names.
 
 2. run the exporter:
+
 ```bash
 terraform init
 terraform apply -var-file=exporter.tfvars
 ```
 
 3. create the environments in env0:
-go to the `env0-resources-generator` folder and run:
+   go to the `env0-resources-generator` folder and run:
+
 ```bash
 # generate the env0 resources terraform files
 terraform init
-terraform apply -var-file=../TFC/out/data.json 
+terraform apply -var-file=../TFC/out/data.json
 
 # create the env0 resources
 cd out
@@ -38,19 +42,20 @@ terraform init
 terraform apply
 ```
 
-Note: you'll need to have the env0 credentials set as environment variables. See [here](https://docs.env0.com/reference/authentication#creating-a-personal-api-key)  about env0 API keys
-
+Note: you'll need to have the env0 credentials set as environment variables. See [here](https://docs.env0.com/reference/authentication#creating-a-personal-api-key) about env0 API keys
 
 4. import the workspaces to env0:
-go to the `TFC/migrate-state` folder and run:
+   go to the `TFC/migrate-state` folder and run:
+
 ```bash
 ./migrate_workspaces.sh
 ```
 
 Note: you'll need to have the env0 credentials set as environment variables and to be logged into Terraform CLI in order to run the above command. In addition, the following environment variables are required:
-- `ENV0_ORG_ID` - env0 organization id 
+
+- `ENV0_ORG_ID` - env0 organization id
 - `TFC_ORG_NAME` - organization name in TFC
-- `ENV0_HOSTNAME` - (Optional) the remote backend URL of env0. `backend.api.env0.com` is used by default 
+- `ENV0_HOSTNAME` - (Optional) the remote backend URL of env0. `backend.api.env0.com` is used by default
 
 the script is supported only for Terraform version <1.6.0
 
@@ -60,3 +65,42 @@ See `migrate-state/README.md` for more details about this phase
 
 Currently the tool will only migrate VCS integrated workspaces, and the migration will be successful only for Github repositories.
 Workspaces that use Terraform versions >=1.6.0, will be using OpenTofu in env0.
+
+## VCS Connection
+
+By default, all of the imported workspaces won't be connected automatically to a VCS. in order to do so, you will have to include the "include_vcs_connection" variable to the code generator TF stack.
+
+1. Before running `terraform apply -var-file=../TFC/out/data.json`, add the following variable
+
+```bash
+terraform apply -var-file=../TFC/out/data.json -var="include_vcs_connection=true"
+```
+
+2. You will notice a new file called `vcs.tf` is created
+
+```hcl
+data "env0_template" "vcs_connected_template" {
+  name = "Name Of VCS Connected Template"
+}
+
+locals {
+  bitbucket_client_key   = data.env0_template.vcs_connected_template.bitbucket_client_key
+  github_installation_id = data.env0_template.vcs_connected_template.github_installation_id
+  token_id               = data.env0_template.vcs_connected_template.token_id
+  is_bitbucket_server    = data.env0_template.vcs_connected_template.is_bitbucket_server
+  is_github_enterprise   = data.env0_template.vcs_connected_template.is_github_enterprise
+  is_gitlab_enterprise   = data.env0_template.vcs_connected_template.is_gitlab_enterprise
+  ssh_keys               = data.env0_template.vcs_connected_template.ssh_keys
+}
+```
+
+3. Go to env0 UI and create a vcs connected template, give it a unique name like "vcs-connection".
+4. After creating this template, replace `"Name Of VCS Connected Template"` with the new template's name.
+5. Resume with the import process.
+
+_DISCLAIMER_
+This utility will provide you a nicer way to connect to a single organization on your vcs. In case you have multiple connections for your imported environments, you might need to manually configure them (in a similar way)
+
+### Modules
+
+NOTE: in case you have modules imported as well, those steps are mandatory as modules are required to be vcs integrated. If you won't include the `include_vcs_connection`, However, this connection won't be applicable to you imported workspaces.

--- a/TFC/main.tf
+++ b/TFC/main.tf
@@ -1,4 +1,4 @@
 resource "local_file" "data" {
-  content  = jsonencode({ "workspaces" : local.final_workspace_list })
+  content  = jsonencode({ "workspaces" : local.final_workspace_list, "modules" : local.tfe_modules})
   filename = "${path.module}/out/data.json"
 }

--- a/TFC/parse_modules.tf
+++ b/TFC/parse_modules.tf
@@ -1,0 +1,10 @@
+locals {
+    modules_url_response    = jsondecode(data.http.modules.response_body)["data"]
+    tfe_modules = [
+        for module in local.modules_url_response : {
+            module_name         = module.attributes.name
+            repository          = module.attributes.vcs-repo.repository-http-url
+            module_provider     = module.attributes.provider
+        }
+    ]
+}

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -5,6 +5,13 @@ data "http" "projects" {
   }
 }
 
+data "http" "modules" {
+  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/registry-modules?page[size]=100"
+  request_headers = {
+    Authorization = "Bearer ${var.tfc_token}"
+  }
+}
+
 data "tfe_workspace_ids" "all" {
   exclude_tags = var.tfc_workspace_exclude_tags
   names        = var.tfc_workspace_names
@@ -24,3 +31,4 @@ data "tfe_variables" "all" {
 
   workspace_id = each.key
 }
+

--- a/env0-resources-generator/main.tf
+++ b/env0-resources-generator/main.tf
@@ -8,7 +8,7 @@ resource "local_file" "main" {
 }
 
 resource "local_file" "environments" {
-  content  = templatefile("terraform_templates/environments.tftpl", { workspaces = var.workspaces })
+  content  = templatefile("terraform_templates/environments.tftpl", { workspaces = var.workspaces, include_vcs_connection = var.include_vcs_connection})
   filename = "${path.module}/out/environments.tf"
 
   provisioner "local-exec" {
@@ -24,3 +24,22 @@ resource "local_file" "projects" {
     command = "terraform fmt ${self.filename}"
   }
 }
+
+resource "local_file" "vcs" {
+  content  = templatefile("terraform_templates/vcs.tftpl", { modules_num = length(var.modules), include_vcs_connection = var.include_vcs_connection })
+  filename = "${path.module}/out/vcs.tf"
+
+  provisioner "local-exec" {
+    command = "terraform fmt ${self.filename}"
+  }
+}
+
+resource "local_file" "modules" {
+  content  = templatefile("terraform_templates/modules.tftpl", { modules = var.modules})
+  filename = "${path.module}/out/modules.tf"
+
+  provisioner "local-exec" {
+    command = "terraform fmt ${self.filename}"
+  }
+}
+

--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -7,18 +7,31 @@ resource "env0_environment" "${workspace.name}" {
     %{ if workspace.type == "terraform" ~}
     is_remote_backend = true
     %{ endif ~}
-    without_template_settings {
-        repository = "https://github.com/${workspace.vcs.account}/${workspace.vcs.repository}"
-        path = "${workspace.vcs.project_root}"
-        revision = "${workspace.vcs.branch}"
-        type = "${workspace.type}"
-        %{ if workspace.type == "terraform" ~}
-        terraform_version = "${workspace.terraform_version}"
-        %{ endif ~}
-        %{ if workspace.type == "opentofu" ~}
-        opentofu_version = "${workspace.opentofu_version}"
-        %{ endif ~}
+    %{ if include_vcs_connection ~}
+    dynamic "without_template_settings" {
+    for_each = [1]
+    content {
+        repository             = "https://github.com/tomer-landesman/templates"
+        path                   = "misc/null-resource"
+        revision               = ""
+        type                   = "opentofu"
+        opentofu_version       = "latest"
+        bitbucket_client_key   = local.bitbucket_client_key
+        github_installation_id = local.github_installation_id
+        token_id               = local.token_id
     }
+    }
+    %{ endif ~}
+    %{ if !include_vcs_connection }
+    without_template_settings {
+        repository             = "https://github.com/tomer-landesman/templates"
+        path                   = "misc/null-resource"
+        revision               = ""
+        type                   = "opentofu"
+        opentofu_version       = "latest"
+
+    } 
+    %{ endif ~}
     %{ for env_var in workspace.env_vars ~}
 
     configuration {

--- a/env0-resources-generator/terraform_templates/main.tftpl
+++ b/env0-resources-generator/terraform_templates/main.tftpl
@@ -10,3 +10,5 @@ terraform {
 }
 
 provider "env0" {}
+
+

--- a/env0-resources-generator/terraform_templates/modules.tftpl
+++ b/env0-resources-generator/terraform_templates/modules.tftpl
@@ -1,0 +1,11 @@
+%{ for module in modules ~}
+resource "env0_module" "${replace(module.module_name," ","_")}" {
+    module_name            = "${module.module_name}"
+    repository             = "${module.repository}"
+    module_provider        = "${module.module_provider}"
+    bitbucket_client_key   = local.bitbucket_client_key
+    github_installation_id = local.github_installation_id 
+    token_id               = local.token_id 
+}
+
+%{ endfor ~}

--- a/env0-resources-generator/terraform_templates/vcs.tftpl
+++ b/env0-resources-generator/terraform_templates/vcs.tftpl
@@ -1,0 +1,11 @@
+%{ if modules_num > 0 || include_vcs_connection ~}
+data "env0_template" "vcs_connected_template" {
+  name = "Name Of VCS Connected Template"
+}
+
+locals {
+   bitbucket_client_key   = data.env0_template.vcs_connected_template.bitbucket_client_key
+   github_installation_id = data.env0_template.vcs_connected_template.github_installation_id 
+   token_id               = data.env0_template.vcs_connected_template.token_id 
+}
+%{ endif ~}

--- a/env0-resources-generator/variables.tf
+++ b/env0-resources-generator/variables.tf
@@ -1,3 +1,12 @@
 variable "workspaces" {
-  description = "The list of workspaces exported. Should be set like this, for example: -var-file=../TFC/out/data.json"
+  description = "The list of exported tfe workspaces."
+}
+
+variable "modules" {
+  description = "The list of exported tfe modules."
+}
+
+variable "include_vcs_connection" {
+  description = "Include the VCS connection on the created environments"
+  default     = false
 }


### PR DESCRIPTION
added support for importing TFC modules to env0.

## Solution

-  added http request to fetch all organization's modules
- parsed the returned modules and added them to the `data.json` file
- generated new modules file based on `data.json` content
- modules require vcs connection, so added an easier way to provide one (by creating a template via the UI and providing it's name)
- generalize the vcs connection so it can be used on environments as well if `include_vcs_connection` flag is provided