### PR TITLE
FIX: variable set description is not parsed correctly

### DIFF
--- a/env0-resources-generator/terraform_templates/variable_sets.tftpl
+++ b/env0-resources-generator/terraform_templates/variable_sets.tftpl
@@ -1,7 +1,9 @@
 %{ for variable_set in variable_sets ~}
 resource "env0_variable_set" "${variable_set.name}" {
     name = "${variable_set.name}"
-    description = "${variable_set.description}"
+    description = <<EOF
+${variable_set.description}
+EOF
 
     %{ for env_var in variable_set.env_vars ~}
 


### PR DESCRIPTION
Variable Set resource failed to be created in case the description had a newline in it.

**Solution** 
- used Terraform’s heredoc syntax to overcome the issue 

**QA**
- [x] created a variable set with newlines at the description and see it is created on env0