### PR TITLE
FEAT: support Gitlab

### DIFF
--- a/TFC/fetch_workspaces.js
+++ b/TFC/fetch_workspaces.js
@@ -1,0 +1,47 @@
+const https = require("https");
+
+function fetchAllWorkspaces(apiUrl, token, callback) {
+  let page = 1;
+  let allWorkspaces = [];
+
+  function fetchPage() {
+    const url = `${apiUrl}&page[number]=${page}`;
+    const options = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
+    https
+      .get(url, options, (res) => {
+        let data = "";
+
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+
+        res.on("end", () => {
+          const response = JSON.parse(data);
+          if (!response.data || response.data.length === 0) {
+            callback(allWorkspaces);
+            return;
+          }
+          allWorkspaces = allWorkspaces.concat(response.data);
+          page++;
+          fetchPage();
+        });
+      })
+      .on("error", (e) => {
+        console.error(`Got error: ${e.message}`);
+        callback(allWorkspaces);
+      });
+  }
+
+  fetchPage();
+}
+
+const [apiUrl, token] = process.argv.slice(2);
+fetchAllWorkspaces(apiUrl, token, (workspaces) => {
+  const result = { workspaces: JSON.stringify(workspaces) };
+  console.log(JSON.stringify(result));
+});

--- a/TFC/parse_projects.tf
+++ b/TFC/parse_projects.tf
@@ -3,7 +3,7 @@ locals {
   projects_response_as_map = tomap({
     for project in local.projects_url_response : project["id"] => project["attributes"]["name"]
   })
-  project_ids          = toset([for workspace in data.tfe_workspace.all : workspace.project_id])
+  project_ids          = toset([for workspace in local.filtered_workspaces_by_name : workspace["relationships"]["project"]["data"]["id"]])
   project_ids_to_names = {
     for id in local.project_ids : id =>
     contains(keys(local.projects_response_as_map), id) ? local.projects_response_as_map[id] : id

--- a/TFC/parse_workspaces.tf
+++ b/TFC/parse_workspaces.tf
@@ -4,11 +4,6 @@ locals {
     for workspace in local.workspaces_from_response : workspace if contains(var.tfc_workspace_names, workspace["attributes"]["name"])
   ]
 
-  ids_from_response = [for workspace in local.filtered_workspaces_by_name : workspace["id"]]
-  names_from_response = [for workspace in local.filtered_workspaces_by_name : workspace["attributes"]["name"]]
-  
-  workspaces_ids  = [for _, id in data.tfe_workspace_ids.all.ids : id]
-  workspace_names = [for name, _ in data.tfe_workspace_ids.all.ids : name]
   all_workspaces  = [
     for workspace in local.filtered_workspaces_by_name : {
       id        = workspace["id"]

--- a/TFC/parse_workspaces.tf
+++ b/TFC/parse_workspaces.tf
@@ -55,7 +55,9 @@ locals {
   environment_type = {
     for workspace in local.all_workspaces :
     workspace.name =>
-    local.opentofu_type_and_version
+    local.split_versions[workspace.name][0] == "latest" ? local.opentofu_type_and_version : parseint(local.split_versions[workspace.name][0], 10) > 1 ? local.opentofu_type_and_version :
+    parseint(local.split_versions[workspace.name][0], 10) == 1 && parseint(local.split_versions[workspace.name][1], 10) >= 6 ? local.opentofu_type_and_version :
+    { type = "terraform" }
   }
 
   final_workspace_list = [

--- a/TFC/parse_workspaces.tf
+++ b/TFC/parse_workspaces.tf
@@ -1,5 +1,5 @@
 locals {
-  workspaces_from_response = jsondecode(data.http.workspaces.response_body)["data"]
+  workspaces_from_response = jsondecode(data.external.workspaces.result.workspaces)
   filtered_workspaces_by_name = [
     for workspace in local.workspaces_from_response : workspace if contains(var.tfc_workspace_names, workspace["attributes"]["name"])
   ]

--- a/TFC/parse_workspaces.tf
+++ b/TFC/parse_workspaces.tf
@@ -4,6 +4,8 @@ locals {
     for workspace in local.workspaces_from_response : workspace if contains(var.tfc_workspace_names, workspace["attributes"]["name"])
   ]
 
+  workspaces_ids = [ for workspace in local.filtered_workspaces_by_name : workspace["id"] ]
+
   all_workspaces  = [
     for workspace in local.filtered_workspaces_by_name : {
       id        = workspace["id"]

--- a/TFC/parse_workspaces.tf
+++ b/TFC/parse_workspaces.tf
@@ -1,10 +1,18 @@
 locals {
+  workspaces_from_response = jsondecode(data.http.workspaces.response_body)["data"]
+  filtered_workspaces_by_name = [
+    for workspace in local.workspaces_from_response : workspace if contains(var.tfc_workspace_names, workspace["attributes"]["name"])
+  ]
+
+  ids_from_response = [for workspace in local.filtered_workspaces_by_name : workspace["id"]]
+  names_from_response = [for workspace in local.filtered_workspaces_by_name : workspace["attributes"]["name"]]
+  
   workspaces_ids  = [for _, id in data.tfe_workspace_ids.all.ids : id]
   workspace_names = [for name, _ in data.tfe_workspace_ids.all.ids : name]
   all_workspaces  = [
-    for name, id in data.tfe_workspace_ids.all.ids : {
+    for workspace in local.filtered_workspaces_by_name : {
       env_vars = [
-        for i, env_var in data.tfe_variables.all[id].variables : {
+        for i, env_var in data.tfe_variables.all[workspace["id"]].variables : {
           hcl       = env_var.hcl
           name      = env_var.name
           sensitive = env_var.sensitive
@@ -12,53 +20,60 @@ locals {
           type      = env_var.category == "terraform" ? "terraform" : "environment"
         }
       ]
-      labels            = data.tfe_workspace.all[name].tag_names
-      name              = data.tfe_workspace.all[name].name
-      description       = data.tfe_workspace.all[name].description
-      terraform_version = trimprefix(data.tfe_workspace.all[name].terraform_version, "~>")
-      project_name      = local.project_ids_to_names[data.tfe_workspace.all[name].project_id]
-      vcs               = {
-        # The "identifier" argument contains the account/organization and the repository names, separated by a slash
-        account = length(data.tfe_workspace.all[name].vcs_repo) > 0 ? split("/", data.tfe_workspace.all[name].vcs_repo[0].identifier)[0] : ""
+      labels            = workspace["attributes"]["tag-names"]
+      name              = workspace["attributes"]["name"]
+      description       = workspace["attributes"]["description"]
+      terraform_version = trimprefix(workspace["attributes"]["terraform-version"], "~>")
+      project_name      = local.project_ids_to_names[workspace["relationships"]["project"]["data"]["id"]]
+      vcs               = lookup(workspace["attributes"], "vcs-repo", null) != null ? {
+
+        account =  workspace["attributes"]["vcs-repo"]["identifier"]
 
         # When the branch for the stack is the repository's default branch, the value is empty so we use the value provided via the variable
-        branch = length(data.tfe_workspace.all[name].vcs_repo) > 0 ? data.tfe_workspace.all[name].vcs_repo[0].branch != "" ? data.tfe_workspace.all[name].vcs_repo[0].branch : "" : ""
+        branch = workspace["attributes"]["vcs-repo"]["branch"]
 
-        project_root = data.tfe_workspace.all[name].working_directory
+        project_root = workspace["attributes"]["working-directory"]
 
         # The "identifier" argument contains the account/organization and the repository names, separated by a slash
-        repository = length(data.tfe_workspace.all[name].vcs_repo) > 0 ? split("/", data.tfe_workspace.all[name].vcs_repo[0].identifier)[1] : ""
-      }
+        repository = workspace["attributes"]["vcs-repo"]["repository-http-url"] 
+      } : null
       sets_names             = [
-        for variable_set in local.all_variable_sets : variable_set.name if contains(variable_set.workspace_ids, id)
+        for variable_set in local.all_variable_sets : variable_set.name if contains(variable_set.workspace_ids, workspace["id"])
       ]
     }
   ]
 
-  workspaces_with_vcs_repositories = [
-    for workspace in local.all_workspaces : workspace if workspace.vcs.repository != ""
-  ]
 
   opentofu_type_and_version = { type = "opentofu", version = "latest" }
   split_versions            = {
-    for workspace in local.workspaces_with_vcs_repositories : workspace.name =>
+    for workspace in local.all_workspaces : workspace.name =>
     split(".", workspace.terraform_version)
   }
 
   environment_type = {
-    for workspace in local.workspaces_with_vcs_repositories :
+    for workspace in local.all_workspaces :
     workspace.name =>
-    parseint(local.split_versions[workspace.name][0], 10) > 1 ? local.opentofu_type_and_version :
-    parseint(local.split_versions[workspace.name][0], 10) == 1 && parseint(local.split_versions[workspace.name][1], 10) >= 6 ? local.opentofu_type_and_version :
-    { type = "terraform" }
+    local.opentofu_type_and_version
   }
 
   final_workspace_list = [
-    for workspace in local.workspaces_with_vcs_repositories :
+    for workspace in local.all_workspaces :
     merge(workspace, {
       type              = local.environment_type[workspace.name].type
       terraform_version = local.environment_type[workspace.name].type == "terraform" ? workspace.terraform_version : null
       opentofu_version  = local.environment_type[workspace.name].type == "opentofu" ? "latest" : null
     })
   ]
+}
+
+output "ids" {
+  value = local.ids_from_response
+}
+
+output "names" {
+  value = local.names_from_response
+}
+
+output "workspaces" { 
+  value = local.all_workspaces
 }

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -13,7 +13,7 @@ data "http" "variable_sets" {
 }
 
 data "http" "workspaces" { 
-  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces"
+  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -12,8 +12,15 @@ data "http" "variable_sets" {
   }
 }
 
+locals {
+  exclude_tags_query = var.tfc_workspace_exclude_tags != null  ? "&search[exclude-tags]=${join(",", var.tfc_workspace_exclude_tags)}" : ""
+  include_tags_query = var.tfc_workspace_include_tags != null ? "&search[tags]=${join(",", var.tfc_workspace_include_tags)}" : ""
+
+  workspaces_query = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100${local.exclude_tags_query}${local.include_tags_query}"
+}
+
 data "http" "workspaces" { 
-  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100&search[exclude-tags]=${join(",", var.tfc_workspace_exclude_tags)}&search[tags]=${join(",", var.tfc_workspace_include_tags)}"
+  url             = local.workspaces_query
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -12,6 +12,13 @@ data "http" "variable_sets" {
   }
 }
 
+data "http" "workspaces" { 
+  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces"
+  request_headers = {
+    Authorization = "Bearer ${var.tfc_token}"
+  }
+}
+
 data "tfe_variable_set" "all" {
   for_each = toset(local.variable_sets_ids)
 
@@ -50,4 +57,8 @@ data "tfe_variables" "all" {
   for_each = toset(local.workspaces_ids)
 
   workspace_id = each.key
+}
+
+output "debug_workspace_list" {
+  value = jsondecode(data.http.workspaces.response_body)["data"]
 }

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -39,20 +39,6 @@ data "http" "modules" {
   }
 }
 
-data "tfe_workspace_ids" "all" {
-  exclude_tags = var.tfc_workspace_exclude_tags
-  names        = var.tfc_workspace_names
-  organization = var.tfc_organization
-  tag_names    = var.tfc_workspace_include_tags
-}
-
-data "tfe_workspace" "all" {
-  for_each = toset(local.workspace_names)
-
-  name         = each.key
-  organization = var.tfc_organization
-}
-
 data "tfe_variables" "all" {
   for_each = toset(local.workspaces_ids)
 

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -58,7 +58,3 @@ data "tfe_variables" "all" {
 
   workspace_id = each.key
 }
-
-output "debug_workspace_list" {
-  value = jsondecode(data.http.workspaces.response_body)["data"]
-}

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -13,7 +13,7 @@ data "http" "variable_sets" {
 }
 
 data "http" "workspaces" { 
-  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100"
+  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100&search[exclude-tags]=${join(",", var.tfc_workspace_exclude_tags)}&search[tags]=${join(",", var.tfc_workspace_include_tags)}"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -19,11 +19,8 @@ locals {
   workspaces_query = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100${local.exclude_tags_query}${local.include_tags_query}"
 }
 
-data "http" "workspaces" { 
-  url             = local.workspaces_query
-  request_headers = {
-    Authorization = "Bearer ${var.tfc_token}"
-  }
+data "external" "workspaces" {
+  program = ["node", "${path.module}/fetch_workspaces.js", local.workspaces_query, var.tfc_token]
 }
 
 data "tfe_variable_set" "all" {

--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -4,16 +4,21 @@ resource "env0_environment" "${workspace.name}" {
     project_id = resource.env0_project.${replace(workspace.project_name," ","_")}.id
     workspace = "${workspace.name}"
     approve_plan_automatically = false
+    
     %{ if workspace.type == "terraform" ~}
     is_remote_backend = true
     %{ endif ~}
-    %{ if include_vcs_connection ~}
+    %{ if workspace.vcs == null  ~}
+    prevent_auto_deploy = true
+    without_template_settings {}
+    %{ endif ~}
+    %{ if include_vcs_connection && workspace.vcs != null  ~}
     # dynamic block is the only way to omit null values. 
     # it is required here because out provider asserts that only one of the vcs token attributes is present
     dynamic "without_template_settings" {
     for_each = [1]
     content {
-        repository = "https://github.com/${workspace.vcs.account}/${workspace.vcs.repository}"
+        repository = "${workspace.vcs.repository}"
         path = "${workspace.vcs.project_root}"
         revision = "${workspace.vcs.branch}"
         type = "${workspace.type}"
@@ -29,9 +34,9 @@ resource "env0_environment" "${workspace.name}" {
         }
     }
     %{ endif ~}
-    %{ if !include_vcs_connection }
+    %{ if !include_vcs_connection && workspace.vcs != null ~} 
     without_template_settings {
-        repository = "https://github.com/${workspace.vcs.account}/${workspace.vcs.repository}"
+        repository = "${workspace.vcs.repository}"
         path = "${workspace.vcs.project_root}"
         revision = "${workspace.vcs.branch}"
         type = "${workspace.type}"

--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -10,7 +10,16 @@ resource "env0_environment" "${workspace.name}" {
     %{ endif ~}
     %{ if workspace.vcs == null  ~}
     prevent_auto_deploy = true
-    without_template_settings {}
+    without_template_settings {
+        repository = "https://repo-placeholder.com"
+        type = "${workspace.type}"
+        %{ if workspace.type == "terraform" ~}
+        terraform_version = "${workspace.terraform_version}"
+        %{ endif ~}
+        %{ if workspace.type == "opentofu" ~}
+        opentofu_version = "${workspace.opentofu_version}"
+        %{ endif ~} 
+    }
     %{ endif ~}
     %{ if include_vcs_connection && workspace.vcs != null  ~}
     # dynamic block is the only way to omit null values. 

--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -3,12 +3,13 @@ resource "env0_environment" "${workspace.name}" {
     name = "${workspace.name}"
     project_id = resource.env0_project.${replace(workspace.project_name," ","_")}.id
     workspace = "${workspace.name}"
-    approve_plan_automatically = false
-    
-    %{ if workspace.type == "terraform" ~}
-    is_remote_backend = true
+    %{ if workspace.vcs != null  ~}
+        approve_plan_automatically = false
     %{ endif ~}
     %{ if workspace.vcs == null  ~}
+    approve_plan_automatically = true
+    is_remote_backend = true
+    is_remote_apply_enabled = true
     prevent_auto_deploy = true
     without_template_settings {
         repository = "https://repo-placeholder.com"
@@ -27,7 +28,7 @@ resource "env0_environment" "${workspace.name}" {
     dynamic "without_template_settings" {
     for_each = [1]
     content {
-        repository = "${workspace.vcs.repository}"
+        repository = "${workspace.vcs.repository}${workspace.vcs.is_gitlab ? ".git" : ""}"
         path = "${workspace.vcs.project_root}"
         revision = "${workspace.vcs.branch}"
         type = "${workspace.type}"
@@ -37,6 +38,9 @@ resource "env0_environment" "${workspace.name}" {
         %{ if workspace.type == "opentofu" ~}
         opentofu_version = "${workspace.opentofu_version}"
         %{ endif ~}
+        %{ if workspace.vcs.is_gitlab ~}
+        gitlab_project_id = local.workspace_to_project_id["${workspace.name}"]
+        %{ endif ~} 
         bitbucket_client_key   = local.bitbucket_client_key
         github_installation_id = local.github_installation_id
         token_id               = local.token_id
@@ -45,7 +49,7 @@ resource "env0_environment" "${workspace.name}" {
     %{ endif ~}
     %{ if !include_vcs_connection && workspace.vcs != null ~} 
     without_template_settings {
-        repository = "${workspace.vcs.repository}"
+        repository = "${workspace.vcs.repository}${workspace.vcs.is_gitlab ? ".git" : ""}"
         path = "${workspace.vcs.project_root}"
         revision = "${workspace.vcs.branch}"
         type = "${workspace.type}"

--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -12,7 +12,7 @@ resource "env0_environment" "${workspace.name}" {
     is_remote_apply_enabled = true
     prevent_auto_deploy = true
     without_template_settings {
-        repository = "https://repo-placeholder.com"
+        repository = "http://."
         type = "${workspace.type}"
         %{ if workspace.type == "terraform" ~}
         terraform_version = "${workspace.terraform_version}"

--- a/env0-resources-generator/terraform_templates/gitlab.tftpl
+++ b/env0-resources-generator/terraform_templates/gitlab.tftpl
@@ -1,0 +1,20 @@
+provider "gitlab" {
+    token = var.gitlab_token
+}
+
+locals {
+    workspace_name_project_names = {
+        %{ for workspace in workspaces ~} 
+        ${workspace.name}: "${workspace.vcs.account}"
+        %{ endfor ~}
+    }
+}
+
+data "gitlab_project" "gitlab_projects" {
+  for_each = local.workspace_name_project_names
+  path_with_namespace = each.value
+}
+
+locals {
+  workspace_to_project_id = { for ws_name, project in data.gitlab_project.gitlab_projects : ws_name => project.id }
+}

--- a/env0-resources-generator/terraform_templates/main.tftpl
+++ b/env0-resources-generator/terraform_templates/main.tftpl
@@ -6,7 +6,14 @@ terraform {
       source  = "env0/env0"
       version = "~> 1.18.12"
     }
+    gitlab = {
+      source = "gitlabhq/gitlab"
+      version = "17.2.0"
+    }
   }
 }
 
-provider "env0" {}
+provider "env0" {
+  api_key = var.env0_api_key
+  api_secret = var.env0_api_secret
+}

--- a/env0-resources-generator/terraform_templates/terraform_variables.tftpl
+++ b/env0-resources-generator/terraform_templates/terraform_variables.tftpl
@@ -1,0 +1,13 @@
+variable "env0_api_key" {
+
+}
+
+variable "env0_api_secret" {
+    
+}
+
+%{ if is_gitlab ~}
+variable "gitlab_token" {
+  description = "The GitLab token to use for authentication."
+}
+%{ endif ~}


### PR DESCRIPTION
This change add support for Gitlab (and other providers as well, to some degree)

- fetch workspaces via script to allow for pagination + details about repositories
- add support for gitlab authentication, autofilling project id for example

## Manual Tests

- [x] tested github / gitlab workspace
- [x] variables
- [x] modules
- [x] variables
- [x] variable sets
- [x] projects