### PR TITLE
Chore: remove `gitlab_project_id`

### DIFF
--- a/env0-resources-generator/terraform_templates/environments.tftpl
+++ b/env0-resources-generator/terraform_templates/environments.tftpl
@@ -38,9 +38,6 @@ resource "env0_environment" "${workspace.name}" {
         %{ if workspace.type == "opentofu" ~}
         opentofu_version = "${workspace.opentofu_version}"
         %{ endif ~}
-        %{ if workspace.vcs.is_gitlab ~}
-        gitlab_project_id = local.workspace_to_project_id["${workspace.name}"]
-        %{ endif ~} 
         bitbucket_client_key   = local.bitbucket_client_key
         github_installation_id = local.github_installation_id
         token_id               = local.token_id

--- a/env0-resources-generator/terraform_templates/gitlab.tftpl
+++ b/env0-resources-generator/terraform_templates/gitlab.tftpl
@@ -9,12 +9,3 @@ locals {
         %{ endfor ~}
     }
 }
-
-data "gitlab_project" "gitlab_projects" {
-  for_each = local.workspace_name_project_names
-  path_with_namespace = each.value
-}
-
-locals {
-  workspace_to_project_id = { for ws_name, project in data.gitlab_project.gitlab_projects : ws_name => project.id }
-}


### PR DESCRIPTION
Remove anything relating to `gitlab_project_id` as it's no longer needed.
See https://github.com/env0/env0/pull/16818