### PR TITLE
reuse token

### DIFF
--- a/TFC/providers.tf
+++ b/TFC/providers.tf
@@ -22,7 +22,9 @@ terraform {
   }
 }
 
-provider "tfe" {}
+provider "tfe" {
+  token = var.tfc_token
+}
 
 provider "http" {}
 


### PR DESCRIPTION
when a customer doesn't have the token previously configured, and we're already asking the customer to provide the token as a variable, lets just reuse it in the provider config.