### PR TITLE
Support set tfc hostname for tfe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # env0-migration-tool
 A repository that contains the necessary files in order to import existing Terraform workspaces from other platforms
+
+## Prerequisites
+Node version 20.x or higher
+Terraform version 1.0.0 or higher

--- a/TFC/README.md
+++ b/TFC/README.md
@@ -15,6 +15,7 @@ you may also specify the following optional variables:
 tfc_workspace_names = ["array of workspace names to export", "wildcards supported"]
 tfc_workspace_include_tags = ["array of tags to include", "wildcards are not supported"]
 tfc_workspace_exclude_tags = ["array of tags to exclude", "wildcards are not supported"]
+tfc_url = "TFC url"
 ```
 
 Note: names and tags are applied together, "with AND operator". exclude tags take precedence over include tags and names.

--- a/TFC/migrate-state/README.md
+++ b/TFC/migrate-state/README.md
@@ -13,6 +13,7 @@ This action will migrate state from one TFC workspace to an env0 environment.
 
 - `ENV0_ORG_ID`: env0 organization id
 - `TFC_ORG_NAME`: organization name in TFC
+- `TFC_HOSTNAME`: organization name in TFC, if not set will default to "app.terraform.io"
 
 ## Usage
 

--- a/TFC/migrate-state/migrate_workspaces.sh
+++ b/TFC/migrate-state/migrate_workspaces.sh
@@ -17,6 +17,12 @@ for env_var in "${required_env_vars[@]}"; do
   check_env_var "$env_var"
 done
 
+# Check if TFC_HOSTNAME is set, if not set it to "app.terraform.io"
+if [ -z "$TFC_HOSTNAME" ]; then
+  export TFC_HOSTNAME="app.terraform.io"
+  echo "TFC_HOSTNAME was not set. Defaulting to app.terraform.io"
+fi
+
 # filter WS names from the json input
 workspaces=$(cat "../out/data.json" | jq -r '.workspaces[] | select(.type == "terraform") | .name')
 

--- a/TFC/migrate-state/tfc_template
+++ b/TFC/migrate-state/tfc_template
@@ -3,6 +3,7 @@ terraform {
     organization = "!!!TFC_ORG_NAME!!!"
     workspaces {
       name = "!!!WS_NAME!!!"
+      hostname = "!!!TFC_HOSTNAME!!!"
     }
   }
 }

--- a/TFC/providers.tf
+++ b/TFC/providers.tf
@@ -24,7 +24,7 @@ terraform {
 
 provider "tfe" {
   token = var.tfc_token
-  hostname = var.tfc_url
+  hostname = var.tfc_hostname
 }
 
 provider "http" {}

--- a/TFC/providers.tf
+++ b/TFC/providers.tf
@@ -24,6 +24,7 @@ terraform {
 
 provider "tfe" {
   token = var.tfc_token
+  hostname = var.tfc_url
 }
 
 provider "http" {}

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -1,12 +1,12 @@
 data "http" "projects" {
-  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/projects?page[size]=100"
+  url             = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/projects?page[size]=100"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }
 }
 
 data "http" "variable_sets" {
-  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/varsets?page[size]=100"
+  url             = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/varsets?page[size]=100"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }
@@ -16,7 +16,7 @@ locals {
   exclude_tags_query = var.tfc_workspace_exclude_tags != null  ? "&search[exclude-tags]=${join(",", var.tfc_workspace_exclude_tags)}" : ""
   include_tags_query = var.tfc_workspace_include_tags != null ? "&search[tags]=${join(",", var.tfc_workspace_include_tags)}" : ""
 
-  workspaces_query = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100${local.exclude_tags_query}${local.include_tags_query}"
+  workspaces_query = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100${local.exclude_tags_query}${local.include_tags_query}"
 }
 
 data "external" "workspaces" {
@@ -37,7 +37,7 @@ data "tfe_variables" "all_sets_variables" {
 }
 
 data "http" "modules" {
-  url             = "https://app.terraform.io/api/v2/organizations/${var.tfc_organization}/registry-modules?page[size]=100"
+  url             = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/registry-modules?page[size]=100"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }

--- a/TFC/tfc_data.tf
+++ b/TFC/tfc_data.tf
@@ -1,12 +1,12 @@
 data "http" "projects" {
-  url             = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/projects?page[size]=100"
+  url             = "https://${var.tfc_hostname}/api/v2/organizations/${var.tfc_organization}/projects?page[size]=100"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }
 }
 
 data "http" "variable_sets" {
-  url             = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/varsets?page[size]=100"
+  url             = "https://${var.tfc_hostname}/api/v2/organizations/${var.tfc_organization}/varsets?page[size]=100"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }
@@ -16,7 +16,7 @@ locals {
   exclude_tags_query = var.tfc_workspace_exclude_tags != null  ? "&search[exclude-tags]=${join(",", var.tfc_workspace_exclude_tags)}" : ""
   include_tags_query = var.tfc_workspace_include_tags != null ? "&search[tags]=${join(",", var.tfc_workspace_include_tags)}" : ""
 
-  workspaces_query = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100${local.exclude_tags_query}${local.include_tags_query}"
+  workspaces_query = "https://${var.tfc_hostname}/api/v2/organizations/${var.tfc_organization}/workspaces?page[size]=100${local.exclude_tags_query}${local.include_tags_query}"
 }
 
 data "external" "workspaces" {
@@ -37,7 +37,7 @@ data "tfe_variables" "all_sets_variables" {
 }
 
 data "http" "modules" {
-  url             = "https://${var.tfc_url}/api/v2/organizations/${var.tfc_organization}/registry-modules?page[size]=100"
+  url             = "https://${var.tfc_hostname}/api/v2/organizations/${var.tfc_organization}/registry-modules?page[size]=100"
   request_headers = {
     Authorization = "Bearer ${var.tfc_token}"
   }

--- a/TFC/variables.tf
+++ b/TFC/variables.tf
@@ -9,6 +9,13 @@ variable "tfc_workspace_names" {
   type        = list(string)
 }
 
+variable "tfc_url" {
+  default     = "app.terraform.io"
+  description = "Custom url for TFC for example for TFE."
+  type        = string
+}
+
+
 variable "tfc_workspace_exclude_tags" {
   default     = null
   description = "List of TFC/TFE workspace tags to exclude when exporting. Excluded tags take precedence over included ones. Wildcards are not supported."

--- a/TFC/variables.tf
+++ b/TFC/variables.tf
@@ -9,9 +9,9 @@ variable "tfc_workspace_names" {
   type        = list(string)
 }
 
-variable "tfc_url" {
+variable "tfc_hostname" {
   default     = "app.terraform.io"
-  description = "Custom url for TFC for example for TFE."
+  description = "Custom hostname for TFC, default is - app.terraform.io."
   type        = string
 }
 


### PR DESCRIPTION
Add support to set hostname for TFE users based on docs should set the `hostname` property
[Docs overview | hashicorp/tfe | Terraform | Terraform Registry](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs)
> This provider is used to interact with the many resources supported by [HCP Terraform](https://www.terraform.io/docs/cloud/index.html). As [Terraform Enterprise](https://www.terraform.io/docs/enterprise/index.html) is a self-hosted distribution of HCP Terraform, this provider supports both Cloud and Enterprise.

> [hostname](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs#hostname-1) - (Optional) The HCP Terraform or Terraform Enterprise hostname to connect to. Defaults to