### PR TITLE
Fix Regex for workspace names

### DIFF
--- a/TFC/parse_workspaces.tf
+++ b/TFC/parse_workspaces.tf
@@ -1,7 +1,11 @@
 locals {
   workspaces_from_response = jsondecode(data.external.workspaces.result.workspaces)
   filtered_workspaces_by_name = [
-    for workspace in local.workspaces_from_response : workspace if contains(var.tfc_workspace_names, workspace["attributes"]["name"])
+    for workspace in local.workspaces_from_response : workspace
+    if anytrue([
+      for pattern in var.tfc_workspace_names :
+        can(regex("^${replace(pattern, "*", ".*")}$", workspace["attributes"]["name"]))
+    ])
   ]
 
   workspaces_ids = [ for workspace in local.filtered_workspaces_by_name : workspace["id"] ]


### PR DESCRIPTION
Our README clearly mentions we can use regex with this syntax for the tfc_workspace_names variable - “example-*”.

In practice I see we have a piece of code that uses the containswhich doesn’t take regex into account and it ends up not working.

Solution: change the code to use the regex function

QA
I have 2 workspaces called : `acme-demo `, `demo`

- `tfc_workspace_names = ["acme-demo"]` => only `acme-demo `
- `tfc_workspace_names = ["acme-*"]` => only `acme-demo `
- `tfc_workspace_names = ["*"] `=> both `acme-demo `, `demo`
- `tfc_workspace_names = ["*-demo","d*"]` => both `acme-demo `, `demo`
- `tfc_workspace_names = ["d3*"]` => NONE

